### PR TITLE
Add context to create and upload archive so that we can stop the upload

### DIFF
--- a/pkg/archive/remote.go
+++ b/pkg/archive/remote.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"encoding/gob"
 	"errors"
 	"log"
@@ -26,7 +27,7 @@ func NewRClipArchiver(si common.ClipStorageInfo) (*RClipArchiver, error) {
 	}, nil
 }
 
-func (rca *RClipArchiver) Create(archivePath string, outputPath string, credentials storage.ClipStorageCredentials, progressChan chan<- int) error {
+func (rca *RClipArchiver) Create(ctx context.Context, archivePath string, outputPath string, credentials storage.ClipStorageCredentials, progressChan chan<- int) error {
 	metadata, err := rca.ClipArchiver.ExtractMetadata(archivePath)
 	if err != nil {
 		return err
@@ -54,7 +55,7 @@ func (rca *RClipArchiver) Create(archivePath string, outputPath string, credenti
 		}
 		log.Println("Archive created, uploading...")
 
-		err = clipStorage.Upload(archivePath, progressChan)
+		err = clipStorage.Upload(ctx, archivePath, progressChan)
 		if err != nil {
 			log.Printf("Unable to upload archive: %+v\n", err)
 			os.Remove(outputPath)

--- a/pkg/clip/clip.go
+++ b/pkg/clip/clip.go
@@ -1,6 +1,7 @@
 package clip
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -74,7 +75,7 @@ func CreateArchive(options CreateOptions) error {
 	return nil
 }
 
-func CreateAndUploadArchive(options CreateOptions, si common.ClipStorageInfo) error {
+func CreateAndUploadArchive(ctx context.Context, options CreateOptions, si common.ClipStorageInfo) error {
 	log.Printf("Archiving...")
 	log.Printf("Creating a new archive from directory: %s\n", options.InputPath)
 
@@ -100,7 +101,7 @@ func CreateAndUploadArchive(options CreateOptions, si common.ClipStorageInfo) er
 		return err
 	}
 
-	err = remoteArchiver.Create(tempFile.Name(), options.OutputPath, options.Credentials, options.ProgressChan)
+	err = remoteArchiver.Create(ctx, tempFile.Name(), options.OutputPath, options.Credentials, options.ProgressChan)
 	if err != nil {
 		return err
 	}
@@ -215,7 +216,7 @@ func StoreS3(storeS3Opts StoreS3Options) error {
 		return err
 	}
 
-	err = a.Create(storeS3Opts.ArchivePath, storeS3Opts.OutputFile, storeS3Opts.Credentials, storeS3Opts.ProgressChan)
+	err = a.Create(context.TODO(), storeS3Opts.ArchivePath, storeS3Opts.OutputFile, storeS3Opts.Credentials, storeS3Opts.ProgressChan)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -164,7 +164,7 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (s3c *S3ClipStorage) Upload(archivePath string, progressChan chan<- int) error {
+func (s3c *S3ClipStorage) Upload(ctx context.Context, archivePath string, progressChan chan<- int) error {
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return fmt.Errorf("failed to open archive <%s>: %v", archivePath, err)
@@ -189,7 +189,7 @@ func (s3c *S3ClipStorage) Upload(archivePath string, progressChan chan<- int) er
 		u.Concurrency = 128
 	})
 
-	_, err = uploader.Upload(context.TODO(), &s3.PutObjectInput{
+	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(s3c.bucket),
 		Key:           aws.String(s3c.key),
 		Body:          pr,


### PR DESCRIPTION
At the moment, once the CreateAndUploadArchive method is called there is no way to stop the upload. If a user cancels the build while the upload is occurring we should stop the upload. 